### PR TITLE
Fix message truncation in retry logic

### DIFF
--- a/src/geo_functions.py
+++ b/src/geo_functions.py
@@ -62,8 +62,8 @@ def call_gpt(user_prompt, system_prompt = COMMON_SYSTEM_PROMPT, model = 'gpt-3.5
                 lup = len(messages[-1]['content'])
                 messages[-1]['content'] = messages[-1]['content'][:int(lup * num_tokens_excess)]  
             if attempt > 5:
-                messages[0]['content'][:-200]       
-                messages[-1]['content'][:-1000]       
+                messages[0]['content'] = messages[0]['content'][:-200]
+                messages[-1]['content'] = messages[-1]['content'][:-1000]
             print(messages)
             import time
             time.sleep(15)


### PR DESCRIPTION
## Summary
- correctly assign sliced content when chat completion retries exceed five attempts

## Testing
- `python -m py_compile src/geo_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_6858df05bc888322829139abae49ed7a