### PR TITLE
Fix leaderboard link text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ load_dataset('GEO-optim/geo-bench')
 
 ## Leaderboard
 
-Leaderboard is available at: [https://huggingface.co/spaces/Pranjal2041/GEO-bench](leaderboard)
+Leaderboard is available at: [Leaderboard](https://huggingface.co/spaces/Pranjal2041/GEO-bench)
 
 ## Citation
 


### PR DESCRIPTION
## Summary
- fix the markdown link in the README so that the link text shows `Leaderboard`
- keep other wording the same

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858df011a988322a3af0034fb8a68fe